### PR TITLE
Handle database does not exist

### DIFF
--- a/lib/active_record/connection_adapters/postgis/create_connection.rb
+++ b/lib/active_record/connection_adapters/postgis/create_connection.rb
@@ -43,9 +43,14 @@ module ActiveRecord  # :nodoc:
           conn = PG.connect(conn_params)
           ConnectionAdapters::PostGISAdapter.new(conn, logger, conn_params, config)
         end
-
+      rescue ::PG::Error => error
+        if error.message.include?(conn_params[:dbname])
+          raise ActiveRecord::NoDatabaseError
+        else
+          raise
+        end
       end
-
     end
+
   end
 end


### PR DESCRIPTION
When running `rake db:drop` on a Rails 6 rc1 project without a database, I get the following exception:

```
oot@f6c827907682:/opt/rails-app# bundle exec rake db:drop
DEPRECATION WARNING: ActionDispatch::Http::ParameterFilter is deprecated and will be removed from Rails 6.1. Use ActiveSupport::ParameterFilter instead. (called from <main> at /usr/local/bundle/gems/grape_logging-1.8.1/lib/grape_logging/util/parameter_filter.rb:2)
DEPRECATION WARNING: Single arity template handlers are deprecated. Template handlers must
now accept two parameters, the view object and the source for the view object.
Change:
  >> Coffee::Rails::TemplateHandler.call(template)
To:
  >> Coffee::Rails::TemplateHandler.call(template, source)
 (called from block in <main> at /usr/local/bundle/gems/coffee-rails-4.2.2/lib/coffee/rails/template_handler.rb:17)
rake aborted!
PG::ConnectionBad: FATAL:  database "your-database-here" does not exist
/usr/local/bundle/gems/pg-0.21.0/lib/pg.rb:56:in `initialize'
/usr/local/bundle/gems/pg-0.21.0/lib/pg.rb:56:in `new'
/usr/local/bundle/gems/pg-0.21.0/lib/pg.rb:56:in `connect'
/usr/local/bundle/bundler/gems/activerecord-postgis-adapter-433daa15eb11/lib/active_record/connection_adapters/postgis/create_connection.rb:43:in `postgis_connection'
/usr/local/bundle/bundler/gems/rails-637e7023837b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:875:in `new_connection'
/usr/local/bundle/bundler/gems/rails-637e7023837b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:919:in `checkout_new_connection'
/usr/local/bundle/bundler/gems/rails-637e7023837b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:898:in `try_to_checkout_new_connection'
/usr/local/bundle/bundler/gems/rails-637e7023837b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:859:in `acquire_connection'
/usr/local/bundle/bundler/gems/rails-637e7023837b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:587:in `checkout'
/usr/local/bundle/bundler/gems/rails-637e7023837b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:431:in `connection'
/usr/local/bundle/bundler/gems/rails-637e7023837b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:1102:in `retrieve_connection'
/usr/local/bundle/bundler/gems/rails-637e7023837b/activerecord/lib/active_record/connection_handling.rb:231:in `retrieve_connection'
/usr/local/bundle/bundler/gems/rails-637e7023837b/activerecord/lib/active_record/connection_handling.rb:199:in `connection'
/usr/local/bundle/bundler/gems/rails-637e7023837b/activerecord/lib/active_record/tasks/database_tasks.rb:59:in `check_protected_environments!'
/usr/local/bundle/bundler/gems/rails-637e7023837b/activerecord/lib/active_record/railties/databases.rake:15:in `block (2 levels) in <main>'
```
Note: This exception happens anytime a rails makes a db call without a database.

Reviewing the `ActiveRecord::ConnectionHandling#postgresql_connection` method, I noticed that it is catching the `PG::Error` exception and raising a `ActiveRecord::NoDatabaseError` exception.

https://github.com/rails/rails/blob/60809e0e1f36da730d0765a1dd781c52366053fb/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L33-L55

This PR, adds the same logic to the `postgis_connection` method.